### PR TITLE
Fix build issue

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,4 +1,4 @@
 node_modules/*
 .nyc_output/*
 coverage/*
-README.md
+*.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ script:
   - npm run coverage:check
 after_success:
   - npm run coverage:report
+after_script:
   - bash <(curl -s -L $SCRIPT_GIST_UPDATE_BADGES) && bash <(curl -s -L $SCRIPT_GIST_PUSH)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at github. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+game-on is an open source project and we love to receive contributions from our community — you! There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into game-on itself.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# game-on [![Build Status](https://travis-ci.org/cl0h/game-on.svg?branch=master)](https://travis-ci.org/cl0h/game-on?branch=master) [![Coverage Status](https://coveralls.io/repos/github/cl0h/game-on/badge.svg?branch=master)](https://coveralls.io/github/cl0h/game-on?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/20fa6c7180787dd18471/maintainability)](https://codeclimate.com/github/cl0h/game-on/maintainability) [![Dependencies Status](https://david-dm.org/cl0h/game-on/status.svg)](https://david-dm.org/cl0h/game-on) 
+# game-on [![Build Status](https://travis-ci.org/Elgismarus/game-on.svg?branch=master)](https://travis-ci.org/Elgismarus/game-on?branch=master) [![Coverage Status](https://coveralls.io/repos/github/Elgismarus/game-on/badge.svg?branch=master)](https://coveralls.io/github/Elgismarus/game-on?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/20fa6c7180787dd18471/maintainability)](https://codeclimate.com/github/Elgismarus/game-on/maintainability) [![Dependencies Status](https://david-dm.org/Elgismarus/game-on/status.svg)](https://david-dm.org/Elgismarus/game-on) 
  
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# game-on [![Build Status](https://travis-ci.org/Elgismarus/game-on.svg?branch=master)](https://travis-ci.org/Elgismarus/game-on?branch=master) [![Coverage Status](https://coveralls.io/repos/github/Elgismarus/game-on/badge.svg?branch=master)](https://coveralls.io/github/Elgismarus/game-on?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/20fa6c7180787dd18471/maintainability)](https://codeclimate.com/github/Elgismarus/game-on/maintainability) [![Dependencies Status](https://david-dm.org/Elgismarus/game-on/status.svg)](https://david-dm.org/Elgismarus/game-on) 
+# game-on [![Build Status](https://travis-ci.org/cl0h/game-on.svg?branch=master)](https://travis-ci.org/cl0h/game-on?branch=master) [![Coverage Status](https://coveralls.io/repos/github/cl0h/game-on/badge.svg?branch=master)](https://coveralls.io/github/cl0h/game-on?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/20fa6c7180787dd18471/maintainability)](https://codeclimate.com/github/cl0h/game-on/maintainability) [![Dependencies Status](https://david-dm.org/cl0h/game-on/status.svg)](https://david-dm.org/cl0h/game-on) 
  
 
 


### PR DESCRIPTION
# Build issue fix

## jshint failing the build
jshint was only ignoring README.md. Any additional .md files where consequently checked. Added *.md to .jshintignore to exclude all .md files.

## Badge update run not matter the build status
Badge update has been moved to after_script. The badge update script should run not matter the status of the build. This is to cover the case of a new branch created with a build failing but the badge hasn't been updated and therefore, showing the status of another branch.